### PR TITLE
Fix python API + small fixes

### DIFF
--- a/pythonAPI/hptt/hptt.py
+++ b/pythonAPI/hptt/hptt.py
@@ -115,10 +115,16 @@ def tensorTransposeAndUpdate(perm, alpha, A, beta, B, numThreads=-1):
         raise ValueError("Unsupported dtype: {}.".format(A.dtype))
 
     # tranpose!
-    tranpose_fn(permc, ctypes.c_int32(A.ndim),
-                scalar_fn(alpha), dataA, sizeA, outerSizeA,
-                scalar_fn(beta), dataB, outerSizeB,
-                ctypes.c_int32(numThreads), ctypes.c_int32(useRowMajor))
+    if 'float' in str(A.dtype):
+        tranpose_fn(permc, ctypes.c_int32(A.ndim),
+                    scalar_fn(alpha), dataA, sizeA, outerSizeA,
+                    scalar_fn(beta), dataB, outerSizeB,
+                    ctypes.c_int32(numThreads), ctypes.c_int32(useRowMajor))
+    else:
+        tranpose_fn(permc, ctypes.c_int32(A.ndim),
+                    scalar_fn(alpha), False, dataA, sizeA, outerSizeA,
+                    scalar_fn(beta), dataB, outerSizeB,
+                    ctypes.c_int32(numThreads), ctypes.c_int32(useRowMajor))
 
 
 def tensorTranspose(perm, alpha, A, numThreads=-1):

--- a/pythonAPI/hptt/hptt.py
+++ b/pythonAPI/hptt/hptt.py
@@ -168,7 +168,7 @@ def transpose(a, axes=None):
         ``a`` with its axes permuted.
     """
     if axes is None:
-        axes = reversed(range(a.ndim))
+        axes = list(reversed(range(a.ndim)))
 
     return tensorTranspose(axes, 1.0, a)
 

--- a/src/hptt.cpp
+++ b/src/hptt.cpp
@@ -171,8 +171,8 @@ void dTensorTranspose( const int *perm, const int dim,
 }
 
 void cTensorTranspose( const int *perm, const int dim,
-                 const float _Complex alpha, bool conjA, const float _Complex *A, const int *sizeA, const int *outerSizeA, 
-                 const float _Complex beta,        float _Complex *B,                   const int *outerSizeB, 
+                 const float alpha, bool conjA, const float *A, const int *sizeA, const int *outerSizeA, 
+                 const float beta,        float *B,                   const int *outerSizeB, 
                  const int numThreads, const int useRowMajor)
 {
    auto plan(std::make_shared<hptt::Transpose<hptt::FloatComplex> >(sizeA, perm, outerSizeA, outerSizeB, dim, 
@@ -182,8 +182,8 @@ void cTensorTranspose( const int *perm, const int dim,
 }
 
 void zTensorTranspose( const int *perm, const int dim,
-                 const double _Complex alpha, bool conjA, const double _Complex *A, const int *sizeA, const int *outerSizeA, 
-                 const double _Complex beta,        double _Complex *B,                   const int *outerSizeB, 
+                 const double alpha, bool conjA, const double *A, const int *sizeA, const int *outerSizeA, 
+                 const double beta,        double *B,                   const int *outerSizeB, 
                  const int numThreads, const int useRowMajor)
 {
    auto plan(std::make_shared<hptt::Transpose<hptt::DoubleComplex> >(sizeA, perm, outerSizeA, outerSizeB, dim, 


### PR DESCRIPTION
Python API is not working properly for complex arrays (see issue https://github.com/springer13/hptt/issues/31).

There is also an issue in benchmark/reference.cpp when floating point are passed to std::conj. std::conj tries to convert floating point to complex number, raising an error at lines 60 and 67. Fixed by creating a new conj function that return the same object if not a complex number (otherwise, it calls std::conj).

For the handles cTensorTranspose and zTensorTranspose removed the __Complex keyword (variables are re-casted to either FloatComplex and DoubleComplex anyway).